### PR TITLE
Type State: Friendly API for Better DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The primary goal of this project is to teach (myself, and everyone else) idiomatic Rust, similar to [mini-redis](https://github.com/tokio-rs/mini-redis), thefore the code is overly heavily documented, there is an article introducing the core concepts [I made a Copilot in Rust 🦀 , here is what I have learned... ](), I recommand to read first, and [PRs description](https://github.com/chenhunghan/oxpilot/pulls?q=is%3Apr) are heavily documented with design patterns used in the code base.
 
-- Indroduction
+- Introduction
 - Design Patterns
   - [Builder and `impl Into<String>`](https://github.com/chenhunghan/oxpilot/pull/1)
-  - [Type State](https://github.com/chenhunghan/oxpilot/pull/4)
+  - [Type State: Friendly API for Better DX](https://github.com/chenhunghan/oxpilot/pull/5)

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -2,7 +2,8 @@ use anyhow::{anyhow, Context, Result};
 
 /// In this file we are using the "Builder" pattern to create `LLM` struc instances. "Builder" pattern is a common design
 /// pattern that used in Rust. It is a creational pattern that lets you construct complex objects step by step.
-///
+/// See https://github.com/chenhunghan/oxpilot/pull/1
+/// 
 /// ```
 /// use oxpilot::llm::LLMBuilder;
 /// #[tokio::main]
@@ -47,6 +48,7 @@ pub struct LLMBuilder<State> {
 }
 
 /// Type state for LLMBuilder
+/// See https://github.com/chenhunghan/oxpilot/pull/5
 /// Init state when `::new()` is called.
 /// 
 /// `pub struct StrucName` is a unit struct. A unit struct is a struct that has no fields.

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -35,7 +35,7 @@ pub struct LLM {
 /// `PartialEq` is a trait for equality comparisons that is used in tests.
 /// https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
 /// e.g. `assert!(LLMBuilder::default() == LLMBuilder::new())`
-#[derive(Default, PartialEq, Clone)]
+#[derive(Default, PartialEq)]
 pub struct LLMBuilder<State> {
     tokenizer_repo_id: Option<String>,
     tokenizer_repo_revision: Option<String>,

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -35,21 +35,64 @@ pub struct LLM {
 /// `PartialEq` is a trait for equality comparisons that is used in tests.
 /// https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
 /// e.g. `assert!(LLMBuilder::default() == LLMBuilder::new())`
-#[derive(Default, PartialEq)]
-pub struct LLMBuilder {
+#[derive(Default, PartialEq, Clone)]
+pub struct LLMBuilder<State> {
     tokenizer_repo_id: Option<String>,
     tokenizer_repo_revision: Option<String>,
     tokenizer_file_name: Option<String>,
     model_repo_id: Option<String>,
     model_repo_revision: Option<String>,
     model_file_name: Option<String>,
+    state: State,
 }
 
-impl LLMBuilder {
-    /// Same as `LLMBuilder::default()`, for those who prefer `LLMBuilder::new()`.
+/// Type state for LLMBuilder
+/// Init state when `::new()` is called.
+/// 
+/// `pub struct StrucName` is a unit struct. A unit struct is a struct that has no fields.
+/// They are most commonly used as marker types.
+/// 
+/// Common struct types in Rust:
+///   - Unit struct: `struct Unit;`
+///   - Classic struct: `struct Classic { a: i32, b: f32 }` Each field in the struct has a name and a data type. 
+///     After a classic struct is defined, the fields in the struct can be accessed by using the syntax <struct>.<field>.
+///   - Tuple struct: `struct Tuple(i32, f32);` are similar to classic structs, but the fields don't have names To access 
+///     the fields in a tuple struct: <tuple>.<index>. The index values in the tuple struct start at zero.
+#[derive(PartialEq)]
+pub struct InitState;
+
+/// Intermedia state, with token repo id, ready to accept model repo id
+#[derive(PartialEq)]
+pub struct WithTokenizerRepoId;
+
+/// Intermedia state, with model repo id, ready to accept model file name
+#[derive(PartialEq)]
+pub struct WithModelRepoId;
+
+/// With both token repo id and model repo id
+#[derive(PartialEq)]
+pub struct ReadyState;
+
+impl LLMBuilder<InitState> {
     pub fn new() -> Self {
-        Self::default()
+        LLMBuilder {
+            tokenizer_repo_id: None,
+            tokenizer_repo_revision: None,
+            tokenizer_file_name: None,
+            model_repo_id: None,
+            model_repo_revision: None,
+            model_file_name: None,
+            state: InitState,
+        }
     }
+}
+
+impl<State> LLMBuilder<State> {
+    // Here we can add methods that are common to all states.
+}
+
+// The initial state
+impl LLMBuilder<InitState> {
     /// Should function parameter be `String` or `&str`....or both?
     /// Short answer: `impl Into<String>` is preferred as it allows both `&str` and `String`.
     ///
@@ -79,11 +122,51 @@ impl LLMBuilder {
     /// ```
     /// Which is more idiomatic?
     /// https://users.rust-lang.org/t/idiomatic-string-parmeter-types-str-vs-asref-str-vs-into-string/7934
-    pub fn tokenizer_repo_id(mut self, tokenizer_repo_id: impl Into<String>) -> Self {
-        self.tokenizer_repo_id = Some(tokenizer_repo_id.into());
-        self
+    pub fn tokenizer_repo_id(
+        self,
+        tokenizer_repo_id: impl Into<String>,
+    ) -> LLMBuilder<WithTokenizerRepoId> {
+        LLMBuilder {
+            tokenizer_repo_id: Some(tokenizer_repo_id.into()),
+            tokenizer_repo_revision: self.tokenizer_repo_revision,
+            tokenizer_file_name: self.tokenizer_file_name,
+            model_repo_id: self.model_repo_id,
+            model_repo_revision: self.model_repo_revision,
+            model_file_name: self.model_file_name,
+            state: WithTokenizerRepoId,
+        }
     }
+}
 
+impl LLMBuilder<WithTokenizerRepoId> {
+    pub fn model_repo_id(self, model_repo_id: impl Into<String>) -> LLMBuilder<WithModelRepoId> {
+        LLMBuilder {
+            tokenizer_repo_id: self.tokenizer_repo_id,
+            tokenizer_repo_revision: self.tokenizer_repo_revision,
+            tokenizer_file_name: self.tokenizer_file_name,
+            model_repo_id: Some(model_repo_id.into()),
+            model_repo_revision: self.model_repo_revision,
+            model_file_name: self.model_file_name,
+            state: WithModelRepoId,
+        }
+    }
+}
+
+impl LLMBuilder<WithModelRepoId> {
+    pub fn model_file_name(self, model_file_name: impl Into<String>) -> LLMBuilder<ReadyState> {
+        LLMBuilder {
+            tokenizer_repo_id: self.tokenizer_repo_id,
+            tokenizer_repo_revision: self.tokenizer_repo_revision,
+            tokenizer_file_name: self.tokenizer_file_name,
+            model_repo_id: self.model_repo_id,
+            model_repo_revision: self.model_repo_revision,
+            model_file_name: Some(model_file_name.into()),
+            state: ReadyState,
+        }
+    }
+}
+
+impl LLMBuilder<ReadyState> {
     pub fn tokenizer_repo_revision(mut self, tokenizer_repo_revision: impl Into<String>) -> Self {
         // `into()` is a trait that converts the value of one type into the value of another type.
         // Since `tokenizer_repo_revision: impl Into<String>` we will convert a string slice into a String.
@@ -96,18 +179,8 @@ impl LLMBuilder {
         self
     }
 
-    pub fn model_repo_id(mut self, model_repo_id: impl Into<String>) -> Self {
-        self.model_repo_id = Some(model_repo_id.into());
-        self
-    }
-
     pub fn model_repo_revision(mut self, model_repo_revision: impl Into<String>) -> Self {
         self.model_repo_revision = Some(model_repo_revision.into());
-        self
-    }
-
-    pub fn model_file_name(mut self, model_file_name: impl Into<String>) -> Self {
-        self.model_file_name = Some(model_file_name.into());
         self
     }
 
@@ -119,13 +192,6 @@ impl LLMBuilder {
         let tokenizer_file_name = self
             .tokenizer_file_name
             .unwrap_or("tokenizer.json".to_string());
-        let model_repo_id = self
-            .model_repo_id
-            .context("model_repo_id is None, forgot to .model_repo_id()?")?;
-        let model_repo_revision = self.model_repo_revision.unwrap_or("main".to_string());
-        let model_file_name = self
-            .model_file_name
-            .context("model_file_name is None, forgot to .model_file_name()?")?;
 
         let hf_hub_api = match hf_hub::api::tokio::Api::new() {
             Ok(hf_hub) => hf_hub,
@@ -152,6 +218,15 @@ impl LLMBuilder {
                 return Result::Err(anyhow!("Failed to init Tokenizer from file {:?}", error))
             }
         };
+
+        let model_repo_id = self
+            .model_repo_id
+            .context("model_repo_id is None, forgot to .model_repo_id()?")?;
+        let model_repo_revision = self.model_repo_revision.unwrap_or("main".to_string());
+        let model_file_name = self
+            .model_file_name
+            .context("model_file_name is None, forgot to .model_file_name()?")?;
+
         let model_repo = hf_hub_api.repo(hf_hub::Repo::with_revision(
             model_repo_id.clone(),
             hf_hub::RepoType::Model,
@@ -183,35 +258,49 @@ impl LLMBuilder {
         })
     }
 }
-
 #[cfg(test)]
 mod llm_builder_tests {
     use super::*;
 
     #[tokio::test]
-    async fn default_is_same_as_new() {
-        assert!(LLMBuilder::default() == LLMBuilder::new());
-    }
-
-    #[tokio::test]
     async fn can_accept_string() {
         let _ = LLMBuilder::new()
+            // mandatory parameters
             .tokenizer_repo_id(String::from("repo"))
+            .model_repo_id(String::from("repo"))
+            .model_file_name(String::from("model.file"))
+            // optional parameters
             .tokenizer_repo_revision(String::from("main"))
             .tokenizer_file_name(String::from("tokenizer.json"))
-            .model_repo_id(String::from("repo"))
-            .model_repo_revision(String::from("main"))
-            .model_file_name(String::from("model.file"));
+            .model_repo_revision(String::from("main"));
     }
 
     #[tokio::test]
     async fn can_accept_string_slice() {
         let _ = LLMBuilder::new()
+            // mandatory parameters
             .tokenizer_repo_id("string_slice")
+            .model_repo_id("repo")
+            .model_file_name("model.file")
+            // optional parameters
             .tokenizer_repo_revision("main")
             .tokenizer_file_name("tokenizer.json")
-            .model_repo_id("repo")
-            .model_repo_revision("main")
-            .model_file_name("model.file");
+            .model_repo_revision("main");
+    }
+
+    #[tokio::test]
+    async fn can_access_values_before_build() {
+        let builder_init_state = LLMBuilder::new();
+        assert!(builder_init_state.state == InitState);
+        let with_token_repo_id_state = builder_init_state.tokenizer_repo_id("token_repo_id");
+        let with_model_repo_id_state = with_token_repo_id_state.model_repo_id("model_repo_id");
+        let ready_state = with_model_repo_id_state.model_file_name("model.file");
+        assert!(ready_state.tokenizer_repo_id.unwrap() == "token_repo_id");
+        assert!(ready_state.model_repo_id.unwrap() == "model_repo_id");
+        assert!(ready_state.model_file_name.unwrap() == "model.file");
+        // all none when not set
+        assert!(ready_state.tokenizer_file_name.is_none());
+        assert!(ready_state.tokenizer_repo_revision.is_none());
+        assert!(ready_state.model_repo_revision.is_none());
     }
 }

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -3,7 +3,7 @@ use anyhow::{anyhow, Context, Result};
 /// In this file we are using the "Builder" pattern to create `LLM` struc instances. "Builder" pattern is a common design
 /// pattern that used in Rust. It is a creational pattern that lets you construct complex objects step by step.
 /// See https://github.com/chenhunghan/oxpilot/pull/1
-/// 
+///
 /// ```
 /// use oxpilot::llm::LLMBuilder;
 /// #[tokio::main]
@@ -50,15 +50,15 @@ pub struct LLMBuilder<State> {
 /// Type state for LLMBuilder
 /// See https://github.com/chenhunghan/oxpilot/pull/5
 /// Init state when `::new()` is called.
-/// 
+///
 /// `pub struct StrucName` is a unit struct. A unit struct is a struct that has no fields.
 /// They are most commonly used as marker types.
-/// 
+///
 /// Common struct types in Rust:
 ///   - Unit struct: `struct Unit;`
-///   - Classic struct: `struct Classic { a: i32, b: f32 }` Each field in the struct has a name and a data type. 
+///   - Classic struct: `struct Classic { a: i32, b: f32 }` Each field in the struct has a name and a data type.
 ///     After a classic struct is defined, the fields in the struct can be accessed by using the syntax <struct>.<field>.
-///   - Tuple struct: `struct Tuple(i32, f32);` are similar to classic structs, but the fields don't have names To access 
+///   - Tuple struct: `struct Tuple(i32, f32);` are similar to classic structs, but the fields don't have names To access
 ///     the fields in a tuple struct: <tuple>.<index>. The index values in the tuple struct start at zero.
 #[derive(PartialEq)]
 pub struct InitState;
@@ -87,14 +87,6 @@ impl LLMBuilder<InitState> {
             state: InitState,
         }
     }
-}
-
-impl<State> LLMBuilder<State> {
-    // Here we can add methods that are common to all states.
-}
-
-// The initial state
-impl LLMBuilder<InitState> {
     /// Should function parameter be `String` or `&str`....or both?
     /// Short answer: `impl Into<String>` is preferred as it allows both `&str` and `String`.
     ///
@@ -138,6 +130,10 @@ impl LLMBuilder<InitState> {
             state: WithTokenizerRepoId,
         }
     }
+}
+
+impl<State> LLMBuilder<State> {
+    // Here we can add methods that are common to all states.
 }
 
 impl LLMBuilder<WithTokenizerRepoId> {


### PR DESCRIPTION
In https://github.com/chenhunghan/oxpilot/pull/1, we implement builder for `LLM`, that is great, we can construct `LLM` with descriptive chain of methods.
```rust
let llm_builder = LLMBuilder::new()
    .tokenizer_repo_id("repo")
    .model_repo_id("repo")
    .model_file_name("file");
let llm = llm_builder.build().await;
``` 

However, let's step aside and be in the shoes the users, if a user tries to use  `LLMBuilder`, it's possible that s/he forgot to support mandatory parameter, for example, forgot to chain `model_repo_id()`.

```rust
let llm_builder = LLMBuilder::new()
    .model_file_name("file");
``` 

This is fine, unlike other language which throws exceptions, Rust's [`Result`](https://doc.rust-lang.org/std/result/)  will propagate error back to user, so there won't be runtime exceptions if the user dealing with the [`Result`](https://doc.rust-lang.org/std/result/) properly:

```rust
let llm_builder = LLMBuilder::new()
    .model_file_name("file");
let llm = match llm_builder.await {
    Ok(llm) => llm,
    Err(error) => {
        // handle the error properly here
    }
};
```
However, what if we can improve the DX, to make the developer knows the problem as soon as possible, to make the feedback loop shorter, ideally when writing the code, i.e., compile time error?

**_Type State_** is a pattern that specify the state in type, and make compiler checks the state before running the code.

Our goal is to make compiler warn us, when mandatory parameters for creation of `LLM` is missing, for example, this will failed to compile:
```rust
let llm_builder = LLMBuilder::new();
let llm = lllm_builder.build().await;
``` 
The compiler will tell the user that, hey, the `build()` can't be used yet, you should not pass!
<p align="center">
<img width="600" alt="Screenshot 2023-11-02 at 20 42 08" src="https://github.com/chenhunghan/oxpilot/assets/1474479/f8261337-e52d-4d59-9429-6201bdb335df">
</p>
and the code intelligent in the editor will support that, hey, there is `tokenizer_repo_id()` method available, would you want to try first?  
<p align="center">
<img width="600" alt="Screenshot 2023-11-02 at 20 44 43" src="https://github.com/chenhunghan/oxpilot/assets/1474479/4f12ffef-34d9-4b90-9327-3fe26b7fe45e">
</p>

We can help our user, to find the next steps by defining the type state

```rust
// Init state when `::new()` is called.
pub struct InitState;

// Intermedia state, with token repo id, ready to accept model repo id
pub struct WithTokenizerRepoId;
```

And, move the implementation to where have the correct state, at the beginning, the state is `InitState`, and user can only use `new()` (does not change state), and `tokenizer_repo_id()`, which will return the instance with `State=WithTokenizerRepoId`.

```rust
impl LLMBuilder<InitState> {
    pub fn new() -> Self {
        LLMBuilder {
           ...
            // does not change state
            state: InitState,
        }
    }
    pub fn tokenizer_repo_id(
        self,
        tokenizer_repo_id: impl Into<String>,
    ) -> LLMBuilder<WithTokenizerRepoId> {
        LLMBuilder {
            ...
            // change state to `WithTokenizerRepoId`
            state: WithTokenizerRepoId,
        }
    }
}
```
If we inspect the builder instance, we will notice that it has `WithTokenizerRepoId` state.
<p align="center">
<img width="500" alt="Screenshot 2023-11-02 at 20 58 57" src="https://github.com/chenhunghan/oxpilot/assets/1474479/9e49bce2-c577-4ec0-8c25-12dff71a21c3">
</p>
That's great! Let's `impl` to builder with `WithTokenizerRepoId` state, so user will know what to do next.

With `tokenizer_repo_id` in place, the next is to set `model_repo_id`, calling `model_repo_id()` will set `model_repo_id` and return `LLMBuilder<WithModelRepoId>`
```rust
// Intermedia state, with model repo id, ready to accept model file name
pub struct WithModelRepoId;

impl LLMBuilder<WithTokenizerRepoId> {
    pub fn model_repo_id(self, model_repo_id: impl Into<String>) -> LLMBuilder<WithModelRepoId> {
        LLMBuilder {
            ...
           // change state to `WithModelRepoId`
            state: WithModelRepoId,
        }
    }
}
```

We are almost ready, the final step is to assign `model_file_name`, then the builder is ready to build.
```rust
/// With both token repo id and model repo id
pub struct ReadyState;

impl LLMBuilder<WithModelRepoId> {
    pub fn model_file_name(self, model_file_name: impl Into<String>) -> LLMBuilder<ReadyState> {
        LLMBuilder {
            ...
           // change state to `WithModelRepoId`
            state: ReadyState,
        }
    }
}
```
Implement the `LLMBuilder<ReadyState>` which adds the `build()` method.
```rust
impl LLMBuilder<ReadyState> {
    pub async fn build(self) -> Result<LLM> { ... }
}
```
Let's it, we have improve our builder, compiler will report errors, when any of mandatory parameters is missing, and avoid the runtime errors.

The final result
```rust
let _ = LLMBuilder::new()
    // mandatory parameters, without these compiler warns
    .tokenizer_repo_id("string_slice")
    .model_repo_id("repo")
    .model_file_name("model.file");
```

Inspect the builder, it has `ReadyState`!
<p align="center">
<img width="500" alt="Screenshot 2023-11-02 at 21 15 30" src="https://github.com/chenhunghan/oxpilot/assets/1474479/f3eacfb1-1bf3-4b17-ab31-60b444a346e6">
</p>