### PR TITLE
Add POST /v1/engines/:engine/completions endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnType": false,
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer",
+    "editor.formatOnSave": true
+  }
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,13 @@ candle-nn = { git = "https://github.com/huggingface/candle.git", version = "0.3.
 candle-transformers = { git = "https://github.com/huggingface/candle.git", version = "0.3.1" }
 anyhow = "1.0"
 dirs = "5.0.1"
+axum = "0.7.1"
+serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.108"
+async-stream = "0.3.5"
+futures = "0.3.29"
+
+[dev-dependencies]
+reqwest = { version = "0.11.22", features = ["json", "stream", "multipart"] }
+reqwest-eventsource = "0.5.0"
+eventsource-stream = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ The primary goal of this project is to teach (myself, and everyone else) idiomat
 - Design Patterns
   - [Builder and `impl Into<String>`](https://github.com/chenhunghan/oxpilot/pull/1)
   - [Type State: Friendly API for Better DX](https://github.com/chenhunghan/oxpilot/pull/5)
+  - [BDD `POST /v1/engines/:engine/completions`](https://github.com/chenhunghan/oxpilot/pull/6)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-pub mod llm;
 pub mod cmd;
-pub mod token;
+pub mod llm;
 pub mod process;
+pub mod token;
+pub mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,10 +108,12 @@ mod tests {
         while let Some(event) = stream.next().await {
             match event {
                 Ok(event) => {
+                    // break the loop at the end of SSE stream
                     if event.data == "[DONE]" {
                         break;
                     }
 
+                    // parse the event data into a Completion object
                     let completion = serde_json::from_str::<Completion>(&event.data).unwrap();
                     completions.push(completion);
                 }
@@ -120,7 +122,7 @@ mod tests {
                 }
             }
         }
-        // return at least one completion object
+        // The endpoint should return at least one completion object
         assert!(completions.len() > 0);
 
         // Check that each completion object has the correct fields

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,12 @@ fn app() -> Router {
         .route("/v1/completions", post(completion))
 }
 
+/// The #[cfg(test)] annotation on the tests module tells Rust to compile and run the test
+/// code only when you run cargo test, not when you run cargo build. This saves compile time when you only
+/// want to build the library and saves space in the resulting compiled artifact because the tests are not included.
 #[cfg(test)]
 mod tests {
+    // imports are only for the tests
     use eventsource_stream::Eventsource; // needed for `.eventsource()`
     use futures::prelude::*; // needed for `.next().await`
     use oxpilot::types::Completion;
@@ -31,6 +35,8 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use tokio::net::TcpListener;
 
+    /// `super::*` means "everything in the parent module"
+    /// It will bring all of the test module’s parent’s items into scope.
     use super::*;
     /// A helper function that spawns our application in the background
     /// and returns its address (e.g. http://127.0.0.1:[random_port])
@@ -46,15 +52,18 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
 
+        // We return the application address to the caller!
         format!("http://{}:{}", _host, port)
     }
 
+    /// The #[tokio::test] annotation on the test_sse_engine_completion function is a macro.
+    /// Similar to #[tokio::main] It transforms the async fn test_sse_engine_completion()
+    /// into a synchronous fn test_sse_engine_completion() that initializes a runtime instance
+    /// and executes the async main function.
     #[tokio::test]
     async fn test_sse_engine_completion() {
         let listening_url = spawn_app("127.0.0.1").await;
-
         let mut completions: Vec<Completion> = vec![];
-
         let model_name = "code-llama-7b";
         let body = serde_json::json!({
             "model": model_name,
@@ -94,6 +103,8 @@ mod tests {
             .bytes_stream()
             .eventsource();
 
+        // iterate over the stream of events
+        // and collect them into a vector of Completion objects
         while let Some(event) = stream.next().await {
             match event {
                 Ok(event) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
+use axum::{routing::post, Router};
 use oxpilot::llm::LLMBuilder;
+use routes::completion::completion;
+pub mod routes;
 
 #[tokio::main]
 async fn main() {
@@ -7,4 +10,134 @@ async fn main() {
         .model_repo_id("TheBloke/CodeLlama-7B-GGUF")
         .model_file_name("codellama-7b.Q2_K.gguf");
     let _ = llm_builder.build().await.expect("Failed to build LLM");
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:6666").await.unwrap();
+    let app = app();
+    axum::serve(listener, app).await.unwrap();
+}
+
+fn app() -> Router {
+    Router::new()
+        .route("/v1/engines/:engine/completions", post(completion))
+        .route("/v1/completions", post(completion))
+}
+
+#[cfg(test)]
+mod tests {
+    use eventsource_stream::Eventsource; // needed for `.eventsource()`
+    use futures::prelude::*; // needed for `.next().await`
+    use oxpilot::types::Completion;
+    use serde_json::Value::Null;
+    use std::time::{SystemTime, UNIX_EPOCH};
+    use tokio::net::TcpListener;
+
+    use super::*;
+    /// A helper function that spawns our application in the background
+    /// and returns its address (e.g. http://127.0.0.1:[random_port])
+    async fn spawn_app(host: impl Into<String>) -> String {
+        let _host = host.into();
+        // Bind to localhost at the port 0, which will let the OS assign an available port to us
+        let listener = TcpListener::bind(format!("{}:0", _host)).await.unwrap();
+        // We retrieve the port assigned to us by the OS
+        let port = listener.local_addr().unwrap().port();
+
+        let _ = tokio::spawn(async move {
+            let app = app();
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        format!("http://{}:{}", _host, port)
+    }
+
+    #[tokio::test]
+    async fn test_sse_engine_completion() {
+        let listening_url = spawn_app("127.0.0.1").await;
+
+        let mut completions: Vec<Completion> = vec![];
+
+        let model_name = "code-llama-7b";
+        let body = serde_json::json!({
+            "model": model_name,
+            "prompt": "Hello, world!",
+            "best_of": 1,
+            "echo": false,
+            "frequency_penalty": 0.0,
+            "logit_bias": Null,
+            "logit_bias": Null,
+            "max_tokens": 16,
+            "n": 1,
+            "presence_penalty": 0,
+            "seed": Null,
+            "stop": Null,
+            "stream": true,
+            "suffix": Null,
+            "temperature": 1,
+            "top_p": 1,
+            "user": Null,
+        });
+
+        let time_before_request = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let mut stream = reqwest::Client::new()
+            .post(&format!(
+                "{}/v1/engines/{engine}/completions",
+                listening_url,
+                engine = model_name
+            ))
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .unwrap()
+            .bytes_stream()
+            .eventsource();
+
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(event) => {
+                    if event.data == "[DONE]" {
+                        break;
+                    }
+
+                    let completion = serde_json::from_str::<Completion>(&event.data).unwrap();
+                    completions.push(completion);
+                }
+                Err(_) => {
+                    panic!("Error in event stream");
+                }
+            }
+        }
+        // return at least one completion object
+        assert!(completions.len() > 0);
+
+        // Check that each completion object has the correct fields
+        // note that we didn't check all the values of the fields because
+        // `serde_json::from_str::<Completion>` should panic if the field is missing or in unexpected format
+        for completion in completions {
+            // id should be a non-empty string
+            assert!(completion.id.len() > 0);
+            assert!(completion.object == "text_completion");
+            assert!(completion.created >= time_before_request);
+            assert!(completion.model == model_name);
+
+            // each completion object should have at least one choice
+            assert!(completion.choices.len() > 0);
+
+            // check that each choice has a non-empty text
+            for choice in completion.choices {
+                assert!(choice.text.len() > 0);
+                // finish_reason should can be None or Some(String)
+                match choice.finish_reason {
+                    Some(finish_reason) => {
+                        assert!(finish_reason.len() > 0);
+                    }
+                    None => {}
+                }
+            }
+
+            assert!(completion.system_fingerprint == "");
+        }
+    }
 }

--- a/src/routes/completion.rs
+++ b/src/routes/completion.rs
@@ -7,38 +7,46 @@ use serde_json::{json, to_string};
 use std::convert::Infallible;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+// Reference: https://github.com/tokio-rs/axum/blob/main/examples/sse/src/main.rs
 pub async fn completion(
+    // `Json<T>` will automatically deserialize the request body to a type `T` as JSON.
     Json(body): Json<CompletionRequest>,
 ) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
+    // `stream!` is a macro from [`async_stream`](https://docs.rs/async-stream/0.3.5/async_stream/index.html)
+    // that makes it easy to create a `futures::stream::Stream` from a generator.
     Sse::new(stream! {
-      yield Ok(
-        SseEvent::default().data(
-          to_string(
-            &json!(
-              Completion {
-                id: "cmpl-".to_string(),
-                object: "text_completion".to_string(),
-                created: SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs(),
-                model: body.model.unwrap_or("unknown".to_string()),
-                choices: vec![Choice {
-                    text: " world!".to_string(),
-                    index: 0,
-                    logprobs: None,
-                    finish_reason: Some("stop".to_string()),
-                }],
-                usage: Usage {
-                    prompt_tokens: 0,
-                    completion_tokens: 0,
-                    total_tokens: 0
-                },
-                system_fingerprint: "".to_string(),
-              }
-            )).unwrap()
-          )
-      );
+        yield Ok(
+          // Create a new `SseEvent` with the default settings.
+          // `SseEvent::default().data("Hello, World!")` will return `data: Hello, World!` as the event text chuck.
+          SseEvent::default().data(
+            // Serialize the `Completion` struct to JSON and return it as the event text chunk.
+            to_string(
+              // json! is a macro from serde_json that makes it easy to create JSON values from a struct.
+              &json!(
+                Completion {
+                  id: "cmpl-".to_string(),
+                  object: "text_completion".to_string(),
+                  created: SystemTime::now()
+                      .duration_since(UNIX_EPOCH)
+                      .unwrap()
+                      .as_secs(),
+                  model: body.model.unwrap_or("unknown".to_string()),
+                  choices: vec![Choice {
+                      text: " world!".to_string(),
+                      index: 0,
+                      logprobs: None,
+                      finish_reason: Some("stop".to_string()),
+                  }],
+                  usage: Usage {
+                      prompt_tokens: 0,
+                      completion_tokens: 0,
+                      total_tokens: 0
+                  },
+                  system_fingerprint: "".to_string(),
+                }
+              )).unwrap()
+            )
+        );
     })
     .keep_alive(KeepAlive::default())
 }

--- a/src/routes/completion.rs
+++ b/src/routes/completion.rs
@@ -1,0 +1,44 @@
+use async_stream::stream;
+use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+use axum::Json;
+use futures::stream::Stream;
+use oxpilot::types::{Choice, Completion, CompletionRequest, Usage};
+use serde_json::{json, to_string};
+use std::convert::Infallible;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub async fn completion(
+    Json(body): Json<CompletionRequest>,
+) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
+    Sse::new(stream! {
+      yield Ok(
+        SseEvent::default().data(
+          to_string(
+            &json!(
+              Completion {
+                id: "cmpl-".to_string(),
+                object: "text_completion".to_string(),
+                created: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs(),
+                model: body.model.unwrap_or("unknown".to_string()),
+                choices: vec![Choice {
+                    text: " world!".to_string(),
+                    index: 0,
+                    logprobs: None,
+                    finish_reason: Some("stop".to_string()),
+                }],
+                usage: Usage {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    total_tokens: 0
+                },
+                system_fingerprint: "".to_string(),
+              }
+            )).unwrap()
+          )
+      );
+    })
+    .keep_alive(KeepAlive::default())
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,0 +1,1 @@
+pub mod completion;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,100 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+// Acknowledgements:
+// https://github.com/AmineDiro/cria/blob/main/src/routes/completions.rs
+// https://github.com/64bit/async-openai/blob/main/async-openai/src/types/types.rs
+
+/// Represents a OpenAI completion response from the API. Note: both the streamed and non-streamed
+/// response objects share the same shape (unlike the chat endpoint).
+/// https://platform.openai.com/docs/api-reference/completions
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Completion {
+    /// A unique identifier for the completion.
+    pub id: String,
+    /// The list of completion choices the model generated for the input prompt.
+    pub choices: Vec<Choice>,
+    /// The Unix timestamp (in seconds) of when the completion was created.
+    pub created: u64,
+    /// The model used for completion.
+    pub model: String,
+    /// This fingerprint represents the backend configuration that the model runs with.
+    ///
+    /// Can be used in conjunction with the `seed` request parameter to understand when backend changes have been
+    /// made that might impact determinism.
+    pub system_fingerprint: String,
+    /// The object type, which is always "text_completion"
+    pub object: String,
+    /// Usage statistics for the completion request.
+    pub usage: Usage,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Choice {
+    pub text: String,
+    pub index: usize,
+    pub logprobs: Option<Logprobs>,
+    // The reason the model stopped generating tokens. This will be stop if the model hit a
+    // natural stop point or a provided stop sequence, length if the maximum number of tokens
+    // specified in the request was reached, or content_filter if content was omitted due to a
+    // flag from our content filters.
+    pub finish_reason: Option<String>,
+}
+
+/// Usage statistics for the completion request.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Usage {
+    /// Number of tokens in the prompt.
+    pub prompt_tokens: usize,
+    /// Number of tokens in the generated completion.
+    pub completion_tokens: usize,
+    /// Total number of tokens used in the request (prompt + completion).
+    pub total_tokens: usize,
+}
+
+/// Not well-documented in OpenAI doc https://platform.openai.com/docs/api-reference/completions/object
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Logprobs {
+    pub tokens: Vec<String>,
+    pub token_logprobs: Vec<Option<usize>>,
+    pub top_logprobs: Vec<serde_json::Value>,
+    pub text_offset: Vec<usize>,
+}
+
+#[derive(Deserialize, Debug)]
+pub enum LogitBias {
+    TokenIds,
+    Tokens,
+}
+
+/// The request body for the completion endpoint.
+/// Only makes `prompt` and `model` required, the rest are optional.
+/// (so we can observe what passes from the copilot clients)
+#[derive(Deserialize, Debug)]
+pub struct CompletionRequest {
+    pub prompt: Option<String>,
+    pub model: Option<String>,
+    pub suffix: Option<String>,
+    pub max_tokens: Option<usize>,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub mirostat_mode: Option<usize>,
+    pub mirostat_tau: Option<f32>,
+    pub mirostat_eta: Option<f32>,
+    pub echo: Option<bool>,
+    pub stream: Option<bool>,
+    pub stop: Option<Vec<String>>,
+    pub logprobs: Option<usize>,
+    pub presence_penalty: Option<f32>,
+    pub frequency_penalty: Option<f32>,
+    pub logit_bias: Option<HashMap<String, f32>>,
+    pub top_k: Option<usize>,
+    pub repeat_penalty: Option<f32>,
+    pub last_n_tokens: Option<usize>,
+    pub logit_bias_type: Option<LogitBias>,
+    pub n: Option<usize>,
+    pub best_of: Option<usize>,
+    pub seed: Option<u64>,
+    pub user: Option<String>,
+}


### PR DESCRIPTION
In this PR, we add the endpoint for the copilot client

From [Code Llama as Drop-In Replacement for Copilot Code Completion](https://dev.to/chenhunghan/use-code-llama-and-other-open-llms-as-drop-in-replacement-for-copilot-code-completion-58hg) we knew that a copilot server is essentially a HTTP server that accepts a request with a prompt and return `JSON` chucks in [Server-Sent Events (SSE)](https://en.wikipedia.org/wiki/Server-sent_events). Let's try to specify the SSE endpoint and creating an Server-Sent Events (SSE) Server using [axum](https://github.com/tokio-rs/axum).

- The URL path of the endpoint. `/v1/engines/:engine/completions`
- The endpoint should accept a `POST` request.
- The endpoint takes a path parameter (`:engine`) and a request body.
- The endpoint return a SSE stream of text chucks (`Content-Type: text/event-stream`). 

Since this endpoint is almost identical to [OpenAI's completions](https://platform.openai.com/docs/guides/text-generation/completions-api) endpoint, we can use `curl` to see the input's input (request body) and the output (SSE text chucks)

```sh
curl https://api.openai.com/v1/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-3.5-turbo-instruct",
    "prompt": "Say this is a test",
    "max_tokens": 7,
    "temperature": 0,
    "stream": true
  }'
# chuck 0
data: {"choices":[{"text":"This ","index":0,"logprobs":null,"finish_reason":null}],
"model":"gpt-3.5-turbo-instruct", "id":"...","object":"text_completion","created":1}
# chuck 1
data: {"choices":[{"text":"is ","index":0,"logprobs":null,"finish_reason":null}],
"model":"gpt-3.5-turbo-instruct", "id":"...","object":"text_completion","created":1}
# chuck 2
data: {"choices":[{"text":"a ","index":0,"logprobs":null,"finish_reason":null}],
"model":"gpt-3.5-turbo-instruct", "id":"...","object":"text_completion","created":1}
# chuck with `"finish_reason":"stop"`
data: {"choices":[{"text":"test.","index":0,"logprobs":null,"finish_reason":"stop"}],
"model":"gpt-3.5-turbo-instruct", "id":"...","object":"text_completion","created":1}
# end of SSE event stream
data: [DONE]
```

#### BDD the Endpoint <a name="bdd"></a>

We will use [`reqwest_eventsource`](https://docs.rs/reqwest-eventsource/latest/reqwest_eventsource/) and its friends in the test to act as the client, which send request to our endpoint `/v1/engines/:engine/completions` and assert the response is what we expected. Since [`reqwest_eventsource`](https://docs.rs/reqwest-eventsource/latest/reqwest_eventsource/) and friends are not used in our final binary, let's add them in `dev-dependencies` in `Cargo.toml`.

```toml
[dev-dependencies]
reqwest = { version = "0.11.22", features = ["json", "stream", "multipart"] }
reqwest-eventsource = "0.5.0"
eventsource-stream = "0.2.3"
```

Add the dummy handler, and axum's router to route requests to `POST /v1/engines/:engine/completions`
```rust
use axum::{routing::post, Router};

async fn completion() -> &'static str {
    "Hello, World!"
}

fn app() -> Router {
    Router::new()
        .route("/v1/engines/:engine/completions", post(completion))
}
```

Translate the spec into the test:
```rust
#[cfg(test)]
mod tests {
    // imports are only for the tests
    // ...

    /// `super::*` means "everything in the parent module"
    /// It will bring all of the test module’s parent’s items into scope.
    use super::*;
    /// A helper function that spawns our application in the background
    /// and returns its address (e.g. http://127.0.0.1:[random_port])
    async fn spawn_app(host: impl Into<String>) -> String {
        let _host = host.into();
        // Bind to localhost at the port 0, which will let the OS assign an available port to us
        let listener = TcpListener::bind(format!("{}:0", _host)).await.unwrap();
        // We retrieve the port assigned to us by the OS
        let port = listener.local_addr().unwrap().port();

        let _ = tokio::spawn(async move {
            let app = app();
            axum::serve(listener, app).await.unwrap();
        });

        // We return the application address to the caller!
        format!("http://{}:{}", _host, port)
    }

    /// The #[tokio::test] annotation on the test_sse_engine_completion function is a macro.
    /// Similar to #[tokio::main] It transforms the async fn test_sse_engine_completion()
    /// into a synchronous fn test_sse_engine_completion() that initializes a runtime instance
    /// and executes the async main function.
    #[tokio::test]
    async fn test_sse_engine_completion() {
        let listening_url = spawn_app("127.0.0.1").await;
        let mut completions: Vec<Completion> = vec![];
        let model_name = "code-llama-7b";
        let body = serde_json::json!({ ... });

        let time_before_request = SystemTime::now()
            .duration_since(UNIX_EPOCH)
            .unwrap()
            .as_secs();
        let mut stream = reqwest::Client::new()
            .post(&format!(
                "{}/v1/engines/{engine}/completions",
                listening_url,
                engine = model_name
            ))
            .header("Content-Type", "application/json")
            .json(&body)
            .send()
            .await
            .unwrap()
            .bytes_stream()
            .eventsource();

        // iterate over the stream of events
        // and collect them into a vector of Completion objects
        while let Some(event) = stream.next().await {
            match event {
                Ok(event) => {
                    // break the loop at the end of SSE stream
                    if event.data == "[DONE]" {
                        break;
                    }
                    
                    // parse the event data into a Completion object
                    let completion = serde_json::from_str::<Completion>(&event.data).unwrap();
                    completions.push(completion);
                }
                Err(_) => {
                    panic!("Error in event stream");
                }
            }
        }
        // The endpoint should return at least one completion object
        assert!(completions.len() > 0);

        // Check that each completion object has the correct fields
        // note that we didn't check all the values of the fields because
        // `serde_json::from_str::<Completion>` should panic if the field 
        // is missing or in unexpected format
        for completion in completions {
            // id should be a non-empty string
            assert!(completion.id.len() > 0);
            assert!(completion.object == "text_completion");
            assert!(completion.created >= time_before_request);
            assert!(completion.model == model_name);

            // each completion object should have at least one choice
            assert!(completion.choices.len() > 0);

            // check that each choice has a non-empty text
            for choice in completion.choices {
                assert!(choice.text.len() > 0);
                // finish_reason should can be None or Some(String)
                match choice.finish_reason {
                    Some(finish_reason) => {
                        assert!(finish_reason.len() > 0);
                    }
                    None => {}
                }
            }

            assert!(completion.system_fingerprint == "");
        }
    }
}
```

Run the tests by `cargo test`, the tests failed, because we haven't implemented the  `completion()`

Add the endpoint, to pass the tests, the endpoint need to response with chucks of SSE struct, let's first fake the values in the struct first, we will connect the endpoint to llm later! It's important to stabilise the HTTP interface first.
```rust
use async_stream::stream;
use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
use axum::Json;
use futures::stream::Stream;
use oxpilot::types::{Choice, Completion, CompletionRequest, Usage};
use serde_json::{json, to_string};
use std::convert::Infallible;
use std::time::{SystemTime, UNIX_EPOCH};

// Reference: https://github.com/tokio-rs/axum/blob/main/examples/sse/src/main.rs
pub async fn completion(
    // `Json<T>` will automatically deserialize the request body to a type `T` as JSON.
    Json(body): Json<CompletionRequest>,
) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
    // `stream!` is a macro from [`async_stream`](https://docs.rs/async-stream/0.3.5/async_stream/index.html) 
    // that makes it easy to create a `futures::stream::Stream` from a generator.
    Sse::new(stream! {
        yield Ok(
          // Create a new `SseEvent` with the default settings.
          // `SseEvent::default().data("Hello, World!")` will return `data: Hello, World!` as the event text chuck.
          SseEvent::default().data(
            // Serialize the `Completion` struct to JSON and return it as the event text chunk.
            to_string(
              // json! is a macro from serde_json that makes it easy to create JSON values from a struct.
              &json!(
                Completion {
                  id: "cmpl-".to_string(),
                  object: "text_completion".to_string(),
                  created: SystemTime::now()
                      .duration_since(UNIX_EPOCH)
                      .unwrap()
                      .as_secs(),
                  model: body.model.unwrap_or("unknown".to_string()),
                  choices: vec![Choice {
                      text: " world!".to_string(),
                      index: 0,
                      logprobs: None,
                      finish_reason: Some("stop".to_string()),
                  }],
                  usage: Usage {
                      prompt_tokens: 0,
                      completion_tokens: 0,
                      total_tokens: 0
                  },
                  system_fingerprint: "".to_string(),
                }
              )).unwrap()
            )
        );
    })
    .keep_alive(KeepAlive::default())
}
```
That's it,  the tests should pass now.
```shell
running 1 test
test tests::test_sse_engine_completion ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```

Alternatively, we can test the copilot e2e:
```shell
cargo run
```
will bind the server at port `6666`, because we have these in `main`:
```rust
#[tokio::main]
async fn main() {
    // ..
    let listener = tokio::net::TcpListener::bind("0.0.0.0:6666").await.unwrap();
    let app = app();
    axum::serve(listener, app).await.unwrap();
}
```

Edit the `settings.json` in VSCode.
```json
"github.copilot.advanced": {
   "debug.overrideProxyUrl": "http://localhost:6666"
}
```

And open any file, we should see ghost texts with ` world!` that is from our copilot server running at port `6666`.
<p align="center">
<img width="200" src="https://github.com/chenhunghan/oxpilot/assets/1474479/40050247-fa0b-4253-9173-863dc720217f">
</p>
<p align="center">
<img width="200" src="https://github.com/chenhunghan/oxpilot/assets/1474479/3b047efa-2621-4879-bc89-080eb67080b3">
</p>
